### PR TITLE
Fix 3'/5' neighbours missing

### DIFF
--- a/Daisychain_knet_web/index.html
+++ b/Daisychain_knet_web/index.html
@@ -164,7 +164,7 @@
     </div>
     </div>
   <footer class='page-footer' style="background-color:white;border-radius:10px;">
-    A project from the <a href='http://appliedbioinformatics.com.au/'>Applied Bioinformatics group</a>. Code for the graphical miner from <a href='https://github.com/Rothamsted/knetminer'>KnetMiner</a> under GNU Lesser General Public License v3.0.
+    A project from the <a href='http://appliedbioinformatics.com.au/'>Applied Bioinformatics group</a>. Code for the graphical miner from <a href='https://github.com/Rothamsted/knetminer'>KnetMiner</a> under <a href='https://github.com/AppliedBioinformatics/gene-daisychain/blob/master/LICENSE'>GNU Lesser General Public License v3.0</a>. Code hosted on <a href='https://github.com/appliedbioinformatics/gene-daisychain'>GitHub</a>.
   </footer>
   </div>
   <script>


### PR DESCRIPTION
For some reason the client was sending a request ('53NB') which the server doesn't even know. The server expected '5NB' or '3NB', now the server also expects '53NB'